### PR TITLE
netconsole shouldn't fail if currently disabled

### DIFF
--- a/root/etc/init/netconsole.conf
+++ b/root/etc/init/netconsole.conf
@@ -25,7 +25,7 @@ script
        mkdir /home/netconsole
     fi
 
-    echo '0' > /sys/kernel/config/netconsole/logging/enabled
+    echo '0' > /sys/kernel/config/netconsole/logging/enabled || true
     echo 'lan0' > /sys/kernel/config/netconsole/logging/dev_name
     MAC='ff:ff:ff:ff:ff:ff'
 


### PR DESCRIPTION
Writing `0` to `enabled` will fail when logging is currently disabled.
Thus the echo command fails and the script aborts.

The script should continue though, so let's just ignore the return value of echo here.